### PR TITLE
Fix issues on win32, regex escapes, and over-matching

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,14 @@
 'use strict';
 
+var path = require('path')
+  , escapeStringRegexp = require('escape-string-regexp')
+  , ESCAPED_NODE_MODULES = escapeStringRegexp('node_modules')
+  , ESCAPED_PATH_SEP = escapeStringRegexp(path.sep);
+
 /**
  * @module
  * @author Oleg Dutchenko <dutchenko.o.dev@gmail.com>
- * @version 1.0.0
+ * @version 1.0.2
  */
 
 // ----------------------------------------
@@ -17,10 +22,30 @@
  * @return {RegExp}
  */
 function babelLoaderExcludeNodeModulesExcept (exceptionList) {
+	var normalizedExceptionList
+	  , alternationGroup
+	  , negativeLookahead
+
 	if (Array.isArray(exceptionList) && exceptionList.length) {
-		return new RegExp(`node_modules[\\/|\\\\](?!(${exceptionList.join('|')})).*`, 'i');
+		// Module names can contain path separators, e.g. "@types/react".
+		// Assume POSIX input and normalize for the current platform.
+		normalizedExceptionList = exceptionList.map(function (moduleName) {
+			// We'll handle trailing path separators when we build the
+			// negative lookahead, so remove them if present.
+			if (moduleName[moduleName.length - 1] === path.posix.sep) {
+				moduleName = moduleName.slice(0, -1);
+			}
+			return moduleName.split(path.posix.sep).join(path.sep);
+		});
+		alternationGroup = '(' + normalizedExceptionList.map(escapeStringRegexp).join('|') + ')';
+		// If the exception list includes e.g. "react", we don't want to
+		// accidentally make an exception for "react-dom", so make sure to
+		// include a trailing path separator inside the negative lookahead.
+		negativeLookahead = '(?!' + alternationGroup + ESCAPED_PATH_SEP + ')';
+		return new RegExp(ESCAPED_NODE_MODULES + ESCAPED_PATH_SEP + negativeLookahead, 'i');
+	} else {
+		return new RegExp(ESCAPED_NODE_MODULES, 'i');
 	}
-	return /node_modules/i;
 }
 
 // ----------------------------------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-loader-exclude-node-modules-except",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Creating a regular expression for excluding node_modules from babel transpiling except for individual modules",
   "main": "index.js",
   "scripts": {
@@ -22,5 +22,8 @@
   "bugs": {
     "url": "https://github.com/WezomAgency/babel-loader-exclude-node-modules-except/issues"
   },
-  "homepage": "https://github.com/WezomAgency/babel-loader-exclude-node-modules-except#readme"
+  "homepage": "https://github.com/WezomAgency/babel-loader-exclude-node-modules-except#readme",
+  "dependencies": {
+    "escape-string-regexp": "^2.0.0"
+  }
 }


### PR DESCRIPTION
This patch fixes three issues:

1. We were previously over-matching exceptions with the same base-name. For example, suppose I wanted to exclude `react` but not `react-dom`:

`1.0.1` (wrong)
```JavaScript
> const nodeModulesExcept = require('babel-loader-exclude-node-modules-except');
> const exceptions = nodeModulesExcept(['react']);
> 'node_modules/react/index.js'.match(exceptions);
null
> 'node_modules/react-dom/index.js'.match(exceptions);
null
```


`This PR` (correct)
```JavaScript
> const nodeModulesExcept = require('babel-loader-exclude-node-modules-except');
> const exceptions = nodeModulesExcept(['react']);
> 'node_modules/react/index.js'.match(exceptions)
null
> 'node_modules/react-dom/index.js'.match(exceptions)
[ 'node_modules/',
  undefined,
  index: 0,
  input: 'node_modules/react-dom/index.js' ]
```

2. We were previously not accommodating win32-style path separators inside module names, e.g. the forward slash inside `@types/react` or `lodash/isequal` would break when running webpack on Windows. This patch assumes POSIX-style input and reformats scoped node modules as appropriate.

3. We were previously not performing regex escapes on the exception list, which could conceivably lead to problems. This patch adds `sindresorhus/escape-string-regexp` as a dependency and uses it to sanitize user input.